### PR TITLE
Adding `keys` fn to get all the log entry keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A tiny value-oriented debugging tool for Clojure(Script), powered by transducers
 - [Usage](#usage)
   - [Basic usage](#basic-usage)
     - [`spy>>` / `log-for`](#spy--log-for)
-    - [`reset-key!` / `completed?`](#reset-key--completed)
+    - [`reset-key!` / `completed?` / `keys`](#reset-key--completed--keys)
     - [`logs` / `reset!`](#logs--reset)
     - [`spy>`](#spy)
     - [`dump`](#dump)
@@ -151,7 +151,7 @@ thus entry keys can also be used as a handy way to collect and group log data:
 ;=> [2 4 6]
 ```
 
-#### `reset-key!` / `completed?`
+#### `reset-key!` / `completed?` / `keys`
 
 To clear the logged data at the log entry `<key>`, call `(reset-key! <key>)`:
 
@@ -202,6 +202,21 @@ You can check if a log entry has been completed using `(completed? <key>)`:
 
 (pm/reset-key! :barbaz)
 (pm/completed? :barbaz)
+;=> false
+```
+
+If you want to know what log entry keys have been logged so far without completing
+any log entry, `keys` suits your desire:
+
+```clojure
+(pm/spy>> :bazqux 10)
+(pm/spy>> :quxquux 20)
+
+(pm/keys)
+;=> #{:bazqux :quxquux}
+(pm/completed? :bazqux)
+;=> false
+(pm/completed? :quxquux)
 ;=> false
 ```
 

--- a/src/postmortem/core.cljc
+++ b/src/postmortem/core.cljc
@@ -1,5 +1,5 @@
 (ns postmortem.core
-  (:refer-clojure :exclude [reset!])
+  (:refer-clojure :exclude [keys reset!])
   (:require [clojure.core :as c]
             #?(:clj [net.cgrand.macrovich :as macros])
             [postmortem.protocols :as proto]
@@ -121,6 +121,14 @@
   ([session]
    (assert (session? session) "Invalid session specified")
    (logs* session)))
+
+(defn keys
+  "Returns all the log entry keys that the session contains.
+  If session is ommited, the keys will be pulled from the current session."
+  ([] (keys (current-session)))
+  ([session]
+   (assert (session? session) "Invalid session specified")
+   (set (proto/-keys session))))
 
 (defn reset-key!
   "Resets log entry for the specified key.

--- a/src/postmortem/protocols.cljc
+++ b/src/postmortem/protocols.cljc
@@ -5,6 +5,7 @@
 
 (defprotocol ILogStorage
   (-add-item! [this id xform item])
+  (-keys [this])
   (-logs [this] [this keys])
   (-reset! [this] [this keys]))
 

--- a/src/postmortem/session.cljc
+++ b/src/postmortem/session.cljc
@@ -63,6 +63,8 @@
   proto/ILogStorage
   (-add-item! [this key xform' item]
     (set! logs (enqueue! logs key xform xform' item)))
+  (-keys [this]
+    (keys logs))
   (-logs [this]
     (collect-logs logs (keys logs)))
   (-logs [this keys]
@@ -84,6 +86,7 @@
     proto/ISession
     proto/ILogStorage
     (-add-item! [this key xform item])
+    (-keys [this])
     (-logs [this] {})
     (-logs [this keys] {})
     (-reset! [this])
@@ -102,6 +105,9 @@
          (-add-item! [this key xform' item]
            (with-lock lock
              (proto/-add-item! session key xform' item)))
+         (-keys [this]
+           (with-lock lock
+             (proto/-keys session)))
          (-logs [this]
            (with-lock lock
              (proto/-logs session)))

--- a/test/postmortem/core_test.cljc
+++ b/test/postmortem/core_test.cljc
@@ -25,6 +25,7 @@
 
 (deftest ^:eftest/synchronized basic-workflow-test
   (fib 5)
+  (is (= #{:add :add-result `fib} (pm/keys)))
   (is (not (pm/completed? :add)))
   (is (= [{:a 0 :b 1}
           {:a 1 :b 1}
@@ -66,6 +67,7 @@
   (is (every? pm/completed? [:add :add-result `fib]))
 
   (pm/reset-key! :add-result)
+  (is (= #{:add `fib} (pm/keys)))
   (is (= {:add [{:a 0 :b 1}
                 {:a 1 :b 1}
                 {:a 1 :b 2}
@@ -80,6 +82,7 @@
          (pm/logs)))
 
   (pm/reset-keys! #{:add `fib})
+  (is (= #{} (pm/keys)))
   (is (= {} (pm/logs))))
 
 ;; Assert this function definition compiles


### PR DESCRIPTION
It's sometimes useful to be able to get all the log entry keys stored in a session without completing the log entries, especially for programmatically managing log entries.

```clojure
(require '[postmortem.core :as pm])

(defn f [x]
  (pm/dump :args)
  (pm/spy>> :ret (inc x)))

(pm/keys) ;=> #{}

(f 42)
;; pm/keys never triggers completion of log entries
(pm/keys) ;=> #{:args :ret}
(pm/completed? :args) ;=> false
(pm/completed? :ret) ;=> false

;; while pm/logs does
(pm/logs) ;=> {:args [{:x 42}], :ret [43]}
(pm/completed? :args) ;=> true
(pm/completed? :ret) ;=> true
```

This feature adds a new method to `ILogStorage`, which comes with a minor breaking change only a few users (if any) may be affected.