### PR TITLE
Add multimethod support for instrumentation

### DIFF
--- a/src/postmortem/instrument/core.cljc
+++ b/src/postmortem/instrument/core.cljc
@@ -23,7 +23,10 @@
   (let [{:keys [raw wrapped]} (get @instrumented-vars v)
         current @v
         to-wrapped (if (= wrapped current) raw current)]
-    (when (fn? to-wrapped)
+    (when (or (fn? to-wrapped)
+              (instance? #?(:clj clojure.lang.MultiFn
+                            :cljs cljs.core.MultiFn)
+                         to-wrapped))
       (let [instrumented (logging-fn to-wrapped sym opts)]
         (swap! instrumented-vars assoc v
                {:raw to-wrapped :wrapped instrumented})


### PR DESCRIPTION
Currently, `postmortem.instrument/instrument` doesn't support multimethods:

```clojure
(require '[postmortem.core :as pm] '[postmortem.instrument :as pi])

(defmulti area :type)
(defmethod area :rectangle [{:keys [width height]}] (* width height))
(defmethod area :circle [{:keys [radius]}] (* Math/PI radius radius))

(pi/instrument `area)
;=> []
(map area [{:type :rectangle :width 3 :height 5} {:type :circle :radius 3}])
;=> (15 28.274333882308138)
(pm/log-for `area)
;=> nil
```