### PR TITLE
instrument's new option for adding :depth to execution logs

### DIFF
--- a/src/postmortem/instrument.cljc
+++ b/src/postmortem/instrument.cljc
@@ -12,7 +12,15 @@
   (defmacro instrument
     "Instruments the vars named by sym-or-syms, a symbol or collection of symbols.
   If a symbol identifies a namespace then all symbols in that namespace will be
-  enumerated. Returns a collection of syms naming the vars instrumented."
+  enumerated. Returns a collection of syms naming the vars instrumented.
+
+  The following options are available:
+
+    - `:with-depth <bool>`: If set to true, each execution log will be attached
+      with the current nesting level (depth) of function calls. Defaults to false.
+    - `:xform <xform>`: Pass transducer <xform> to the logging operators
+    - `:session <session>`: Use <session> to store the execution log
+  "
     ([sym-or-syms]
      (macros/case :clj `(clj/instrument ~sym-or-syms)
                   :cljs `(postmortem.instrument.cljs/instrument ~sym-or-syms)))


### PR DESCRIPTION
It would sometimes be useful if each log item in `instrument`'s execution logs had an additional key that indicates their nesting level (depth) of function calls at invocation time, especially when debugging a recursive function.

This PR adds another option `{:with-depth true}` for optionally adding such a key to each log item in the execution logs, like the following:

```clojure
(require '[postmortem.core :as pm]
         '[postmortem.instrument :as pi])

(defn fact [n]
  (if (= n 0)
    1
    (* n (fact (dec n)))))

;; without :with-depth option
(pi/instrument `fact)
(fact 5) ;=> 120
(pm/log-for `fact)
;=> [{:args (5)}
;    {:args (4)}
;    {:args (3)}
;    {:args (2)}
;    {:args (1)}
;    {:args (0)}
;    {:args (0), :ret 1}
;    {:args (1), :ret 1}
;    {:args (2), :ret 2}
;    {:args (3), :ret 6}
;    {:args (4), :ret 24}
;    {:args (5), :ret 120}]

(pm/reset!)

;; with :with-depth option
(pi/instrument `fact {:with-depth true})
(fact 5) ;=> 120
(pm/log-for `fact)
;=> [{:args (5), :depth 1}
;    {:args (4), :depth 2}
;    {:args (3), :depth 3}
;    {:args (2), :depth 4}
;    {:args (1), :depth 5}
;    {:args (0), :depth 6}
;    {:args (0), :ret 1, :depth 6}
;    {:args (1), :ret 1, :depth 5}
;    {:args (2), :ret 2, :depth 4}
;    {:args (3), :ret 6, :depth 3}
;    {:args (4), :ret 24, :depth 2}
;    {:args (5), :ret 120, :depth 1}]
```