### PR TITLE
Add frequencies fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A tiny value-oriented debugging tool for Clojure(Script), powered by transducers
   - [Basic usage](#basic-usage)
     - [`spy>>` / `log-for`](#spy--log-for)
     - [`reset-key!` / `completed?` / `keys`](#reset-key--completed--keys)
-    - [`logs` / `reset!`](#logs--reset)
+    - [`logs` / `frequencies` / `reset!`](#logs--frequencies--reset)
     - [`spy>`](#spy)
     - [`dump`](#dump)
   - [Integration with transducers](#integration-with-transducers)
@@ -220,7 +220,7 @@ any log entry, `keys` suits your desire:
 ;=> false
 ```
 
-#### `logs` / `reset!`
+#### `logs` / `frequencies` / `reset!`
 
 You can also logs some data to more than one log entries at once.
 In such a case, `logs` is more useful to look into the whole log data
@@ -243,8 +243,34 @@ than just calling `log-for` for each log entry:
 ;    :sum [0 1 3 6 10 15]}
 ```
 
-Similarly, `reset!` is useful to clear the whole log data at a time, rathar than
-clearing each individual log entry one by one calling `reset-key!`:
+Alternatively, `frequencies` helps you grasp how many log items have been
+stored so far for each log entry key, without seeing the actual log data:
+
+```clojure
+(defn sum [n]
+  (loop [i 0 sum 0]
+    (pm/spy>> :i i)
+    (if (> i n)
+      sum
+      (recur (inc i)
+             (pm/spy>> :sum (+ i sum))))))
+
+(sum 5) ;=> 15
+
+(pm/frequencies)
+;=> {:i 7 :sum 6}
+
+;; As compared to:
+;; (pm/logs)
+;; => {:i [0 1 2 3 4 5 6],
+;      :sum [0 1 3 6 10 15]}
+```
+
+Note that once you call `frequencies`, all the log entries will be
+*completed*, as with the `logs` fn.
+
+Analogous to `logs`, `reset!` is useful to clear the whole log data at a time,
+rathar than clearing each individual log entry one by one calling `reset-key!`:
 
 ```clojure
 (pm/logs)

--- a/src/postmortem/core.cljc
+++ b/src/postmortem/core.cljc
@@ -1,5 +1,5 @@
 (ns postmortem.core
-  (:refer-clojure :exclude [keys reset!])
+  (:refer-clojure :exclude [frequencies keys reset!])
   (:require [clojure.core :as c]
             #?(:clj [net.cgrand.macrovich :as macros])
             [postmortem.protocols :as proto]
@@ -129,6 +129,17 @@
   ([session]
    (assert (session? session) "Invalid session specified")
    (set (proto/-keys session))))
+
+(defn frequencies
+  "Returns a frequency map, which is a map of log entry key to a number
+  that indicates how many log items have been logged for the log entry.
+  If session is omitted, frequencies for the current session will be
+  returned."
+  ([] (frequencies (current-session)))
+  ([session]
+   (assert (session? session) "Invalid session specified")
+   (->> (logs* session)
+        (into {} (map (fn [[k xs]] [k (count xs)]))))))
 
 (defn reset-key!
   "Resets log entry for the specified key.

--- a/test/postmortem/core_test.cljc
+++ b/test/postmortem/core_test.cljc
@@ -65,6 +65,7 @@
                 {:n 0 :a 5 :b 8}]}
          (pm/logs)))
   (is (every? pm/completed? [:add :add-result `fib]))
+  (is (pm/frequencies) {:add 5, :add-result 6, `fib 6})
 
   (pm/reset-key! :add-result)
   (is (= #{:add `fib} (pm/keys)))
@@ -83,7 +84,8 @@
 
   (pm/reset-keys! #{:add `fib})
   (is (= #{} (pm/keys)))
-  (is (= {} (pm/logs))))
+  (is (= {} (pm/logs)))
+  (is (= {} (pm/frequencies))))
 
 ;; Assert this function definition compiles
 ;; cf. https://github.com/athos/postmortem/issues/2


### PR DESCRIPTION
I often want to know how many log items are stored so far for each log entry before looking into the actual log data.

This PR introduces a new function `frequencies` for doing that:

```clojure
(require '[postmortem.core :as pm]
         '[postmortem.instrument :as pi])

(declare my-odd?)

(defn my-even? [n]
  (or (= n 0) (my-odd? (dec n))))

(defn my-odd? [n]
  (and (not= n 0) (my-even? (dec n))))

(pi/instrument `[my-even? my-odd?])
(my-even? 42) ;=> true

(pm/frequencies)
;=> #:user{my-even? 44, my-odd? 42}
```

which is just a shorthand for:

```clojure
(into {} (map (fn [[k xs]] [k (count xs)])) (pm/logs))
```