### PR TITLE
Adding stats, a short alias for frequencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A tiny value-oriented debugging tool for Clojure(Script), powered by transducers
   - [Basic usage](#basic-usage)
     - [`spy>>` / `log-for`](#spy--log-for)
     - [`reset-key!` / `completed?` / `keys`](#reset-key--completed--keys)
-    - [`logs` / `frequencies` / `reset!`](#logs--frequencies--reset)
+    - [`logs` / `stats` / `reset!`](#logs--stats--reset)
     - [`spy>`](#spy)
     - [`dump`](#dump)
   - [Integration with transducers](#integration-with-transducers)
@@ -220,7 +220,7 @@ any log entry, `keys` suits your desire:
 ;=> false
 ```
 
-#### `logs` / `frequencies` / `reset!`
+#### `logs` / `stats` / `reset!`
 
 You can also logs some data to more than one log entries at once.
 In such a case, `logs` is more useful to look into the whole log data
@@ -243,7 +243,7 @@ than just calling `log-for` for each log entry:
 ;    :sum [0 1 3 6 10 15]}
 ```
 
-Alternatively, `frequencies` helps you grasp how many log items have been
+Alternatively, `stats` helps you grasp how many log items have been
 stored so far for each log entry key, without seeing the actual log data:
 
 ```clojure
@@ -257,7 +257,7 @@ stored so far for each log entry key, without seeing the actual log data:
 
 (sum 5) ;=> 15
 
-(pm/frequencies)
+(pm/stats)
 ;=> {:i 7 :sum 6}
 
 ;; As compared to:
@@ -266,8 +266,12 @@ stored so far for each log entry key, without seeing the actual log data:
 ;      :sum [0 1 3 6 10 15]}
 ```
 
-Note that once you call `frequencies`, all the log entries will be
+Note that once you call `stats`, all the log entries will be
 *completed*, as with the `logs` fn.
+
+For those who are using older versions (<= 0.4.0), `pm/stats` is the new name
+for `pm/frequencies` added in 0.4.1. They can be used totally interchangeablly.
+Now `pm/stats` is recommended for primary use.
 
 Analogous to `logs`, `reset!` is useful to clear the whole log data at a time,
 rathar than clearing each individual log entry one by one calling `reset-key!`:

--- a/src/postmortem/core.cljc
+++ b/src/postmortem/core.cljc
@@ -130,16 +130,21 @@
    (assert (session? session) "Invalid session specified")
    (set (proto/-keys session))))
 
-(defn frequencies
-  "Returns a frequency map, which is a map of log entry key to a number
+(defn stats
+  "Returns a stats map, which is a map of log entry key to a number
   that indicates how many log items have been logged for the log entry.
-  If session is omitted, frequencies for the current session will be
+  If session is omitted, stats for the current session will be
   returned."
-  ([] (frequencies (current-session)))
+  ([] (stats (current-session)))
   ([session]
    (assert (session? session) "Invalid session specified")
    (->> (logs* session)
         (into {} (map (fn [[k xs]] [k (count xs)]))))))
+
+(defn frequencies
+  "Alias for `stats`. See the docstring for `stats` for details."
+  ([] (stats (current-session)))
+  ([session] (stats session)))
 
 (defn reset-key!
   "Resets log entry for the specified key.

--- a/test/postmortem/core_test.cljc
+++ b/test/postmortem/core_test.cljc
@@ -65,7 +65,7 @@
                 {:n 0 :a 5 :b 8}]}
          (pm/logs)))
   (is (every? pm/completed? [:add :add-result `fib]))
-  (is (pm/frequencies) {:add 5, :add-result 6, `fib 6})
+  (is (pm/stats) {:add 5, :add-result 6, `fib 6})
 
   (pm/reset-key! :add-result)
   (is (= #{:add `fib} (pm/keys)))
@@ -85,7 +85,7 @@
   (pm/reset-keys! #{:add `fib})
   (is (= #{} (pm/keys)))
   (is (= {} (pm/logs)))
-  (is (= {} (pm/frequencies))))
+  (is (= {} (pm/stats))))
 
 ;; Assert this function definition compiles
 ;; cf. https://github.com/athos/postmortem/issues/2


### PR DESCRIPTION
While the `frequencies` fn is useful to get a quick overview of the current whole log state, that name is a little bit too long to type into the REPL over and over again.
This PR adds `stats` as a short alias that is easier to type in than `frequencies`.