### PR TITLE
Simple logger implemented around one-shot session

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,23 @@ it will behave as if you attached that transducer to the implicit session:
 (f) ;=> [1 4 9 16]
 ```
 
+A *multi logger* is a variant of the simple logger that has three arities, i.e.
+2-arg for `(spy>> <arg1> <arg2>)`, 1-arg for `(log-for <arg>)` and 0-arg for `(logs)`.
+
+```clojure
+(def f (pm/make-multi-logger))
+
+(loop [n 5, sum 0]
+  (if (= n 0)
+    sum
+    (recur (f :n (dec n)) (f :sum (+ sum n)))))
+;=> 15
+
+(f) ;=> {:n [4 3 2 1 0], :sum [5 9 12 14 15]}
+(f :n) ;=> [4 3 2 1 0]
+(f :sum) ;=> [5 9 12 14 15]
+```
+
 ### Instrumentation
 
 Postmortem has one more powerful feature: instrumentation. It looks like clojure.spec's

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ A tiny value-oriented debugging tool for Clojure(Script), powered by transducers
     - [Attaching a transducer](#attaching-a-transducer)
     - [`void-session`](#void-session)
     - [`make-unsafe-session`](#make-unsafe-session)
+  - [Simple logger](#simple-logger)
   - [Instrumentation](#instrumentation)
 - [Related works](#related-works)
 
@@ -718,6 +719,42 @@ thread safety and performance.
 ```
 
 In ClojureScript, `make-session` is completely identical to `make-unsafe-session`.
+
+### Simple logger
+
+Postmortem 0.5.0+ provides a new feature, *simple loggers*. A simple logger
+essentially works like `spy>>` and `log-for`, but offers a more simplified API
+for common use cases.
+
+A simple logger is implemented as a function with two arities that closes over
+an implicit session:
+
+```clojure
+(def f (pm/make-logger))
+
+(f 1)
+(f 2)
+(f 3)
+(f 4)
+(f) ;=> [1 2 3 4]
+```
+
+As you may see, if a simple logger is called with one argument, it acts like
+`(spy>> :key <argument>)` on the implicit session whereas if called with no
+argument, it acts like `(log-for :key)`.
+
+If you create a simple logger by passing an transducer as the optional argument,
+it will behave as if you attached that transducer to the implicit session:
+
+```clojure
+(def f (pm/make-logger (map #(* % %))))
+
+(f 1)
+(f 2)
+(f 3)
+(f 4)
+(f) ;=> [1 4 9 16]
+```
 
 ### Instrumentation
 

--- a/src/postmortem/core.cljc
+++ b/src/postmortem/core.cljc
@@ -247,7 +247,8 @@
   
   A multi logger is a variant of the simple logger. If called with
   two arguments, it acts like `(spy>> <arg1> <arg2>)` on the implicit
-  session. If called with no argument, it acts like `(logs)`.
+  session. If called with one argument, it acts like (log-for <arg>)`.
+  If called with no argument, it acts like `(logs)`.
 
   If a transducer is passed as the optional argument, it will be attached
   to the implicit session."
@@ -256,5 +257,6 @@
    (let [sess (make-session)]
      (fn
        ([] (logs sess))
+       ([key] (log-for sess key))
        ([key val]
         (spy>> sess key xform val))))))

--- a/src/postmortem/core.cljc
+++ b/src/postmortem/core.cljc
@@ -223,3 +223,12 @@
      `(spy> (locals) ~session ~key ~xform)))
 
   )
+
+(defn make-logger
+  ([] (make-logger identity))
+  ([xform]
+   (let [sess (make-session)]
+     (fn
+       ([] (log-for sess :key))
+       ([val]
+        (spy>> sess :key xform val))))))

--- a/src/postmortem/core.cljc
+++ b/src/postmortem/core.cljc
@@ -225,6 +225,15 @@
   )
 
 (defn make-logger
+  "Creates a simple logger.
+
+  A simple logger is a function with two arities that closes over
+  an implicit session. If called with one argument, it acts like
+  `(spy>> :key <arg>)` on the implicit session. If called with
+  no argument, it acts like `(log-for :key)`.
+
+  If a transducer is passed as the optional argument, it will be attached
+  to the implicit session."
   ([] (make-logger identity))
   ([xform]
    (let [sess (make-session)]

--- a/src/postmortem/core.cljc
+++ b/src/postmortem/core.cljc
@@ -241,3 +241,20 @@
        ([] (log-for sess :key))
        ([val]
         (spy>> sess :key xform val))))))
+
+(defn make-multi-logger
+  "Creates a multi logger.
+  
+  A multi logger is a variant of the simple logger. If called with
+  two arguments, it acts like `(spy>> <arg1> <arg2>)` on the implicit
+  session. If called with no argument, it acts like `(logs)`.
+
+  If a transducer is passed as the optional argument, it will be attached
+  to the implicit session."
+  ([] (make-multi-logger identity))
+  ([xform]
+   (let [sess (make-session)]
+     (fn
+       ([] (logs sess))
+       ([key val]
+        (spy>> sess key xform val))))))

--- a/test/postmortem/core_test.cljc
+++ b/test/postmortem/core_test.cljc
@@ -202,3 +202,13 @@
        (is (= 19999 (->> (pm/log-for sess :f) first :i)))))
 
    )
+
+(deftest logger-test
+  (let [f (pm/make-logger)]
+    (is (= [0 1 2 3 4] (map f (range 5))))
+    (is (= [0 1 2 3 4] (f)))
+    (is (= 42 (f 42)))
+    (is (= [0 1 2 3 4] (f))))
+  (let [f (pm/make-logger (filter even?))]
+    (is (= [0 1 2 3 4 5 6 7 8 9] (map f (range 10))))
+    (is (= [0 2 4 6 8] (f)))))

--- a/test/postmortem/core_test.cljc
+++ b/test/postmortem/core_test.cljc
@@ -212,3 +212,19 @@
   (let [f (pm/make-logger (filter even?))]
     (is (= [0 1 2 3 4 5 6 7 8 9] (map f (range 10))))
     (is (= [0 2 4 6 8] (f)))))
+
+(deftest multi-logger-test
+  (let [f (pm/make-multi-logger)]
+    (is (= 15
+           (loop [n 5 sum 0]
+             (if (= n 0)
+               sum
+               (recur (f :n (dec n)) (f :sum (+ sum n)))))))
+    (is (= {:n [4 3 2 1 0], :sum [5 9 12 14 15]} (f))))
+  (let [f (pm/make-multi-logger (take 3))]
+    (is (= 15
+           (loop [n 5 sum 0]
+             (if (= n 0)
+               sum
+               (recur (f :n (dec n)) (f :sum (+ sum n)))))))
+    (is (= {:n [4 3 2], :sum [5 9 12]} (f)))))

--- a/test/postmortem/core_test.cljc
+++ b/test/postmortem/core_test.cljc
@@ -220,11 +220,15 @@
              (if (= n 0)
                sum
                (recur (f :n (dec n)) (f :sum (+ sum n)))))))
-    (is (= {:n [4 3 2 1 0], :sum [5 9 12 14 15]} (f))))
+    (is (= {:n [4 3 2 1 0], :sum [5 9 12 14 15]} (f)))
+    (is (= [4 3 2 1 0] (f :n)))
+    (is (= [5 9 12 14 15] (f :sum))))
   (let [f (pm/make-multi-logger (take 3))]
     (is (= 15
            (loop [n 5 sum 0]
              (if (= n 0)
                sum
                (recur (f :n (dec n)) (f :sum (+ sum n)))))))
-    (is (= {:n [4 3 2], :sum [5 9 12]} (f)))))
+    (is (= {:n [4 3 2], :sum [5 9 12]} (f)))
+    (is (= [4 3 2] (f :n)))
+    (is (= [5 9 12] (f :sum)))))


### PR DESCRIPTION
This PR explores how useful a *simple logger* is, such as:

```clojure
(require '[postmortem.core :as pm])

(def f (pm/make-logger (filter even?)))

(map f (range 10))
(f) ;=> [0 2 4 6 8]
```

This looks much simpler than the code with existing APIs:

```clojure
(def sess (pm/make-session (filter even?)))

(map #(pm/spy>> sess :key identity %) (range 10))
(pm/log-for sess :key)
```

A simple logger is implemented with a one-shot session, and the user doesn't have to reset it every time after peeking the log. This nature would be especially useful when you repeat the cycle of "debug, modify, (re-)eval".