### PR TITLE
Indexed sessions

### DIFF
--- a/src/postmortem/core.cljc
+++ b/src/postmortem/core.cljc
@@ -43,11 +43,22 @@
     (fn [] session)))
 
 (defn indexed
+  "Creates an indexed session based on the given session.
+  An indexed session manages an auto-incremental index and attaches it to each
+  log item. How the session attaches the index can be specified by a function f
+  passed as an optional argument. The function takes two arguments, the index
+  and the log item, and returns a new log item. The default function is
+  `(fn [id item] {:id id :val item})`."
+  {:added "0.5.1"}
   ([session] (indexed session #(array-map :id %1 :val %2)))
   ([session f]
    (session/indexed session f)))
 
 (defn make-indexed-session
+  "Creates and returns a new indexed session.
+  Equivalent to `(indexed (make-session))` or `(indexed (make-session) f)`.
+  See the docstring for `indexed` for details."
+  {:added "0.5.1"}
   ([] (indexed (make-session)))
   ([f] (indexed (make-session) f)))
 

--- a/src/postmortem/core.cljc
+++ b/src/postmortem/core.cljc
@@ -42,6 +42,15 @@
   (let [session (session/void-session)]
     (fn [] session)))
 
+(defn indexed
+  ([session] (indexed session #(array-map :id %1 :val %2)))
+  ([session f]
+   (session/indexed session f)))
+
+(defn make-indexed-session
+  ([] (indexed (make-session)))
+  ([f] (indexed (make-session) f)))
+
 (def ^:dynamic *current-session*
   "Dynamic var bound to the current session. Don't use this directly, call
   (current-session) instead."

--- a/src/postmortem/session.cljc
+++ b/src/postmortem/session.cljc
@@ -96,6 +96,33 @@
     (-complete! [this])
     (-complete! [this keys])))
 
+(defn indexed [session f]
+  (let [id (atom -1)]
+    (reify
+      proto/ISession
+      proto/ILogStorage
+      (-add-item! [_ key xform item]
+        (proto/-add-item! session key xform (f (swap! id inc) item)))
+      (-keys [_]
+        (proto/-keys session))
+      (-logs [_]
+        (proto/-logs session))
+      (-logs [_ keys]
+        (proto/-logs session keys))
+      (-reset! [_]
+        (proto/-reset! session)
+        (reset! id -1)
+        nil)
+      (-reset! [_ keys]
+        (proto/-reset! session keys))
+      proto/ICompletable
+      (-completed? [_ key]
+        (proto/-completed? session key))
+      (-complete! [_]
+        (proto/-complete! session))
+      (-complete! [_ keys]
+        (proto/-complete! session keys)))))
+
 #?(:clj
    (defn synchronized [session]
      (let [^ReentrantLock lock (ReentrantLock.)]


### PR DESCRIPTION
This PR adds indexed sessions.

An indexed session is a session that automatically attaches a sequential number (or index) to each log item.

```clojure
(require '[postmortem.core :as pm])

(pm/set-current-session! (pm/make-indexed-session))

(pm/spy>> :foo :a)
(pm/spy>> :bar :b)
(pm/spy>> :foo :c)
(pm/logs)
;=> {:foo [{:id 0 :val :a} {:id 2 :val :c}]
;    :bar [{:id 1 :val :b}]}

(pm/set-current-session! (pm/make-indexed-session (fn [id item] (assoc item :i id))))

(pm/spy>> :point {:x 100 :y 100})
(pm/spy>> :point {:x 200 :y 200})
(pm/spy>> :point {:x 300 :y 300})
(pm/log-for :point)
;=> [{:i 0 :x 100 :y 100} {:i 1 :x 200 :y 200} {:i 2 :x 300 :y 300}]
```