### PR TITLE
merged-logs

### DIFF
--- a/src/postmortem/core.cljc
+++ b/src/postmortem/core.cljc
@@ -142,6 +142,19 @@
    (assert (session? session) "Invalid session specified")
    (logs* session)))
 
+(defn merged-logs
+  "Merges all the log entries into a single vector.
+  This function optionally takes a function as an argument to specify how to
+  handle each log entry key. The function must take the log entry key and
+  the log item, and return a new log item. The default function is
+  `(fn [key item] item)`."
+  {:added "0.5.1"}
+  ([] (merged-logs (fn [_key val] val)))
+  ([f] (merged-logs (current-session) f))
+  ([session f]
+   (into [] (mapcat (fn [[k v]] (map (partial f k) v)))
+         (logs* session))))
+
 (defn keys
   "Returns all the log entry keys that the session contains.
   If session is omitted, the keys will be pulled from the current session."

--- a/test/postmortem/core_test.cljc
+++ b/test/postmortem/core_test.cljc
@@ -238,6 +238,24 @@
 
    )
 
+(deftest merged-logs-test
+  (pm/with-session (pm/make-indexed-session)
+    (pm/spy>> :foo :a)
+    (pm/spy>> :bar :b)
+    (pm/spy>> :foo :c)
+    (is (= [{:id 0 :val :a}
+            {:id 1 :val :b}
+            {:id 2 :val :c}]
+           (sort-by :id (pm/merged-logs)))))
+  (pm/with-session (pm/make-indexed-session)
+    (pm/spy>> :foo :a)
+    (pm/spy>> :bar :b)
+    (pm/spy>> :foo :c)
+    (is (= [{:id 0 :key :foo :val :a}
+            {:id 1 :key :bar :val :b}
+            {:id 2 :key :foo :val :c}]
+           (sort-by :id (pm/merged-logs #(assoc %2 :key %1)))))))
+
 (deftest logger-test
   (let [f (pm/make-logger)]
     (is (= [0 1 2 3 4] (map f (range 5))))


### PR DESCRIPTION
Added `merged-logs`, which merges all the log entries into a single vector. It's mainly intended to be used with indexed sessions:

```clojure
(require '[postmortem.core :as pm])

(pm/set-current-session! (pm/make-indexed-session))

(pm/spy>> :foo :a)
(pm/spy>> :bar :b)
(pm/spy>> :foo :c)
(->> (pm/merged-logs (fn [key item] (assoc item :key key)))
     (sort-by :id))
;=> ({:id 0 :key :foo :val :a}
;    {:id 1 :key :bar :val :b}
;    {:id 2 :key :foo :val :c})
```

Or, it can be useful for handling time-series log data across multiple log entries:

```clojure
(pm/set-current-session! (pm/make-session (map #(array-map :val % :t (System/nanoTime)))))

(pm/spy>> :foo :a)
(pm/spy>> :bar :b)
(pm/spy>> :foo :c)
(->> (pm/merged-logs #(assoc %2 :key %1))
     (sort-by :t))
;=> ({:val :a, :t 569110489730145, :key :foo}
;    {:val :b, :t 569114678123945, :key :bar}
;    {:val :c, :t 569120404022116, :key :foo}
```