### PR TITLE
Fix overriding warning on 1.11

### DIFF
--- a/src/postmortem/xforms.cljc
+++ b/src/postmortem/xforms.cljc
@@ -71,7 +71,7 @@
              (do (vreset! prev v)
                  (rf acc input)))))))))
 
-(defn- abs ^double [^double x]
+(defn- abs* ^double [^double x]
   #?(:clj (Math/abs x)
      :cljs (js/Math.abs x)))
 
@@ -87,7 +87,7 @@
           (let [p @prev
                 v (f input)]
             (if (or (= p ::none)
-                    (>= (abs (- v p)) interval))
+                    (>= (abs* (- v p)) interval))
               (do (vreset! prev v)
                   (rf acc input))
               acc))))))))


### PR DESCRIPTION
Clojure 1.11 started to show the following warning due to its addition of the `abs` function:

```
WARNING: abs already refers to: #'clojure.core/abs in namespace: postmortem.xforms, being replaced by: #'postmortem.xforms/abs
```

This PR fixes this warning by renaming the function.