### PR TITLE
Babashka support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,11 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '11'
-    - name: Setup Clojure CLI
-      uses: DeLaGuardo/setup-clojure@6.0
+    - name: Setup Clojure CLI & Babashka
+      uses: DeLaGuardo/setup-clojure@9.5
       with:
-        tools-deps: latest
+        cli: latest
+        bb: latest
     - name: Cache deps
       uses: actions/cache@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
       run: clojure -M:1.8:test
     - name: Run CLJS tests on Node
       run: clojure -M:test:cljs:test-cljs
+    - name: Run tests on Babashka
+      run: bb test
     - name: Measure test coverage
       run: clojure -A:test:coverage
     - name: Upload coverage report to CodeCov

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A tiny data-oriented debugging tool for Clojure(Script), powered by transducers
   - Logs are just Clojure data, so you can use DataScript, REBL or whatever tools for more sophisticated log analysis
 - [Integration with transducers](#integration-with-transducers) enables various flexible logging strategies
 - [Instrumentation](#instrumentation) on vars makes it easier to debug functions without touching their code
-- Supports Clojure/ClojureScript/self-hosted ClojureScript
+- Supports most of Clojure platforms (namely, Clojure, ClojureScript, self-hosted ClojureScript and Babashka)
 - Possible to use for debugging multi-threaded programs
 
 ## Synopsis
@@ -85,6 +85,7 @@ A tiny data-oriented debugging tool for Clojure(Script), powered by transducers
 
 - Clojure 1.8+, or
 - ClojureScript 1.10.238+, or
+- Babashka v0.10.163+, or
 - Planck 2.24.0+, or
 - Lumo 1.10.1+
 

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,2 @@
+{:paths ["src"]
+ :deps {net.cgrand/macrovich {:mvn/version "0.2.1"}}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,2 +1,3 @@
-{:paths ["src"]
- :deps {net.cgrand/macrovich {:mvn/version "0.2.1"}}}
+{:paths ["src" "test"]
+ :deps {net.cgrand/macrovich {:mvn/version "0.2.1"}}
+ :tasks {test postmortem.test-runner/-main}}

--- a/src/postmortem/core.cljc
+++ b/src/postmortem/core.cljc
@@ -11,7 +11,7 @@
 (defn session?
   "Returns true if x is a session."
   [x]
-  (satisfies? proto/ISession x))
+  (satisfies? #?(:bb proto/ILogStorage :default proto/ISession) x))
 
 (defn make-unsafe-session
   "Creates and returns a new thread-unsafe session.

--- a/src/postmortem/instrument/clj.cljc
+++ b/src/postmortem/instrument/clj.cljc
@@ -2,10 +2,14 @@
   (:require [clojure.string :as str]
             [postmortem.instrument.core :as instr]
             [postmortem.utils :refer [with-lock]])
-  (:import [java.util.concurrent.locks ReentrantLock]))
+  #?@(:bb []
+      :clj ((:import [java.util.concurrent.locks ReentrantLock]))))
 
-(def ^:private ^ReentrantLock instrument-lock
-  (ReentrantLock.))
+#?(:bb
+   (def instrument-lock (Object.))
+   :clj
+   (def ^:private ^ReentrantLock instrument-lock
+     (ReentrantLock.)))
 
 (defn- collectionize [x]
   (if (symbol? x)

--- a/src/postmortem/utils.cljc
+++ b/src/postmortem/utils.cljc
@@ -8,14 +8,15 @@
   ;; to avoid using the locking macro, which is problematic in some environments (see CLJ-1472)
   (defmacro with-lock [lock & body]
     (macros/case
-      :clj
-      `(let [lock# ~lock]
-         (.lock lock#)
-         (try
-           ~@body
-           (finally
-             (.unlock lock#))))
+     :clj
+      #?(:bb
+         `(locking ~lock ~@body)
+         :clj
+         `(let [lock# ~lock]
+            (.lock lock#)
+            (try
+              ~@body
+              (finally
+                (.unlock lock#)))))
       :cljs
-      `(do ~@body)))
-
-  )
+      `(do ~@body))))

--- a/src/postmortem/utils.cljc
+++ b/src/postmortem/utils.cljc
@@ -12,7 +12,7 @@
       #?(:bb
          `(locking ~lock ~@body)
          :clj
-         `(let [lock# ~lock]
+         `(let [^java.util.concurrent.locks.ReentrantLock lock# ~lock]
             (.lock lock#)
             (try
               ~@body


### PR DESCRIPTION
To support Babashka:

- Use `locking` instead of `ReentrantLock` (as Babashka doesn't support it)
- Determine if an object is a session by checking if it implements `ILogStorage`, rather than the `ISession` marker protocol (as Babashka at this moment doesn't support marker protocols on deftypes)